### PR TITLE
Potential fix for code scanning alert no. 7: Disabled Spring CSRF protection

### DIFF
--- a/2_identity-access/src/main/java/com/wizdevtech/identityaccess/config/SecurityConfig.java
+++ b/2_identity-access/src/main/java/com/wizdevtech/identityaccess/config/SecurityConfig.java
@@ -33,12 +33,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**", "/health", "/api/avatars/preview", "/debug-public").permitAll()
                         .anyRequest().permitAll() // Temporarily allow all requests
-                );
+                )
+                .csrf().and(); // Re-enable CSRF protection
 
         // Apply JWT filter if needed
         // http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
Potential fix for [https://github.com/Wiz-DevTech/prettygirllz/security/code-scanning/7](https://github.com/Wiz-DevTech/prettygirllz/security/code-scanning/7)

To fix the issue, CSRF protection should be re-enabled by removing the `http.csrf(AbstractHttpConfigurer::disable)` line. If there are specific endpoints or use cases where CSRF protection is not required, those should be explicitly excluded using Spring's CSRF configuration options. Additionally, the `http.cors(AbstractHttpConfigurer::disable)` line should be reviewed, as disabling CORS might also have security implications.

The changes will be made in the `securityFilterChain` method of the `SecurityConfig` class. The `http.csrf(AbstractHttpConfigurer::disable)` line will be removed, and CSRF protection will be enabled by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
